### PR TITLE
Move change log to separate file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## 0.2.3
+Updated the display name.
+Fixed a bug that fails to parse task constructor's name without parameters.
+
+## 0.2.2
+Added unit tests.
+Fixed some minor bugs.
+
+## 0.2.0
+Added Task Dependency proposals.
+Fixed some bugs in Task parser.
+
+## 0.1.3
+
+Republished after installing node modules and compiling server source codes.
+
+## 0.1.0
+
+Initial release.

--- a/README.md
+++ b/README.md
@@ -116,26 +116,3 @@ The extension automatically detects the Java and Android plugin used in the Grad
 ## Known Issues
 
 * Syntax highlighting doesn't always work consistently with task constructor with parameters in parentheses, i.e. `task foo(type: Bar) {...}` and `task foo {...}` 
-
-## Release Notes
-
-### 0.2.3
-Updated the display name.
-Fixed a bug that fails to parse task constructor's name without parameters.
-
-### 0.2.2
-Added unit tests.
-Fixed some minor bugs.
-
-### 0.2.0
-Added Task Dependency proposals.
-Fixed some bugs in Task parser.
-
-### 0.1.3
-
-Republished after installing node modules and compiling server source codes.
-
-### 0.1.0
-
-Initial release.
-


### PR DESCRIPTION
Besides being good practice, recording the changes in a separate `CHANGELOG.md` file allows `vscode` to render it directly from the plugin manager under the `Changelog` tab. The preamble is taken from [keepachangelog](http://keepachangelog.com/en/1.0.0/). 