### PR TITLE
Resolve issue #11

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -97,11 +97,14 @@ function validateTextDocument(textDocument: TextDocument): void {
 				if (/^[a-zA-Z]+$/.test(line3) == true) {
 					parseComplete = true;
 
-					// Check if already used in the document
-					if (scriptBlocks[line3] == undefined) {
-						scriptBlocks[line3] = [i];
-					} else {
-						scriptBlocks[line3].push(i);
+					// Check for keywords
+					if(line3 != "else" && line3 != "static") {
+						// Check if already used in the document
+						if (scriptBlocks[line3] == undefined) {
+							scriptBlocks[line3] = [i];
+						} else {
+							scriptBlocks[line3].push(i);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This fixes issue #11, "Duplication Validation: 'else' has already been used
in this build script." It checks the script block name against known keywords (currently `else` and `static`) before reporting it as a duplicate. This is a bit of a hack and it seems like there might be a better way of doing this, but I was unable to find one.